### PR TITLE
kibana: case sensitive fields

### DIFF
--- a/elkc7sn/Vagrantfile
+++ b/elkc7sn/Vagrantfile
@@ -29,6 +29,7 @@ Vagrant.configure("2") do |config|
     m.vm.network "private_network", ip: "#{ip}",
       virtualbox__intnet: "NatNetwork3"
     m.vm.network "forwarded_port", guest: 5601, host: 5601
+    m.vm.network "forwarded_port", guest: 9200, host: 9200
     ## Host-specific resource settings
     m.vm.provider :virtualbox do |vb|
         vb.customize ["modifyvm", :id, "--memory", "1024"]

--- a/elkc7sn/ansible/files/elasticsearch-template.conf
+++ b/elkc7sn/ansible/files/elasticsearch-template.conf
@@ -1,0 +1,169 @@
+{
+  "template": "filebeat-*",
+  "settings": {
+    "index.refresh_interval": "5s"
+  },
+  "mappings": {
+    "_default_": {
+      "_all": {
+        "enabled": true,
+        "omit_norms": true
+      },
+      "dynamic_templates": [
+        {
+          "message_field": {
+            "match": "message",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "index": "analyzed",
+              "omit_norms": true,
+              "fielddata": {
+                "format": "disabled"
+              }
+            }
+          }
+        },
+        {
+          "string_fields": {
+            "match": "*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "string",
+              "index": "analyzed",
+              "omit_norms": true,
+              "fielddata": {
+                "format": "disabled"
+              },
+              "fields": {
+                "raw": {
+                  "type": "string",
+                  "index": "not_analyzed",
+                  "doc_values": true,
+                  "ignore_above": 256
+                }
+              }
+            }
+          }
+        },
+        {
+          "float_fields": {
+            "match": "*",
+            "match_mapping_type": "float",
+            "mapping": {
+              "type": "float",
+              "doc_values": true
+            }
+          }
+        },
+        {
+          "double_fields": {
+            "match": "*",
+            "match_mapping_type": "double",
+            "mapping": {
+              "type": "double",
+              "doc_values": true
+            }
+          }
+        },
+        {
+          "byte_fields": {
+            "match": "*",
+            "match_mapping_type": "byte",
+            "mapping": {
+              "type": "byte",
+              "doc_values": true
+            }
+          }
+        },
+        {
+          "short_fields": {
+            "match": "*",
+            "match_mapping_type": "short",
+            "mapping": {
+              "type": "short",
+              "doc_values": true
+            }
+          }
+        },
+        {
+          "integer_fields": {
+            "match": "*",
+            "match_mapping_type": "integer",
+            "mapping": {
+              "type": "integer",
+              "doc_values": true
+            }
+          }
+        },
+        {
+          "long_fields": {
+            "match": "*",
+            "match_mapping_type": "long",
+            "mapping": {
+              "type": "long",
+              "doc_values": true
+            }
+          }
+        },
+        {
+          "date_fields": {
+            "match": "*",
+            "match_mapping_type": "date",
+            "mapping": {
+              "type": "date",
+              "doc_values": true
+            }
+          }
+        },
+        {
+          "geo_point_fields": {
+            "match": "*",
+            "match_mapping_type": "geo_point",
+            "mapping": {
+              "type": "geo_point",
+              "doc_values": true
+            }
+          }
+        }
+      ],
+      "properties": {
+        "@timestamp": {
+          "type": "date",
+          "doc_values": true
+        },
+        "@version": {
+          "type": "string",
+          "index": "not_analyzed",
+          "doc_values": true
+        },
+        "geoip": {
+          "type": "object",
+          "dynamic": true,
+          "properties": {
+            "ip": {
+              "type": "ip",
+              "doc_values": true
+            },
+            "location": {
+              "type": "geo_point",
+              "doc_values": true
+            },
+            "latitude": {
+              "type": "float",
+              "doc_values": true
+            },
+            "longitude": {
+              "type": "float",
+              "doc_values": true
+            }
+          }
+        },
+        "host": {
+          "type": "string",
+          "index": "not_analyzed"
+        }
+      }
+    }
+  }
+}

--- a/elkc7sn/ansible/files/elasticsearch@elk0.yml
+++ b/elkc7sn/ansible/files/elasticsearch@elk0.yml
@@ -58,7 +58,9 @@ node.data: true
 #
 ## address on privnet for talking to cluster in Vagrant, 
 ## localhost to talk with Kibana and Logstash
-#network.host: ["127.0.0.1"]
+# NOTE: we are exposing ES to other VMs and to the host, so that it's easier to debug.
+# Do not use this configuration on production
+network.host: ["10.0.3.20", "10.0.2.15", "localhost"]
 #
 # Set a custom port for HTTP:
 #

--- a/elkc7sn/ansible/files/logstash.conf
+++ b/elkc7sn/ansible/files/logstash.conf
@@ -30,6 +30,7 @@ output {
   elasticsearch {
     hosts => localhost
     index => "%{[@metadata][beat]}-%{+YYYY.MM.dd}"
+    template => "/etc/logstash/elasticsearch-template.conf"
   }
   stdout {
     codec => rubydebug

--- a/elkc7sn/ansible/roles/logstash/tasks/main.yml
+++ b/elkc7sn/ansible/roles/logstash/tasks/main.yml
@@ -11,5 +11,11 @@
       owner: root
       group: root
       backup: yes
+  - copy:
+      dest: /etc/logstash/elasticsearch-template.conf
+      src:  elasticsearch-template.conf
+      owner: root
+      group: root
+      backup: yes
   ## do not set to autostart, for flexible testing
   - service: name=logstash state=started


### PR DESCRIPTION
* Introduces an example of field for which we explicitly
  require ES to index it in case insensitive mode (actually
  to not analyzed at all).

Signed-off-by: Samuele Kaplun <kaplun@protonmail.com>